### PR TITLE
Fix application freeze issue in Gradio app for follow-up questions

### DIFF
--- a/MCP/MCP_Mistral_app_demo/gradio_app.py
+++ b/MCP/MCP_Mistral_app_demo/gradio_app.py
@@ -275,8 +275,9 @@ with gr.Blocks(css="""
                 update_config_btn = gr.Button("Update Configuration")
     
     # Set up the chat functionality
-    def respond(message, chat_history):
+    async def respond(message, chat_history):
         """Process the message and update the chat history"""
+        global agent, mcp_clients, available_tools
         if not message.strip():
             return chat_history
             
@@ -285,12 +286,10 @@ with gr.Blocks(css="""
         
         # Initialize agent if needed
         if agent is None:
-            loop = asyncio.get_event_loop()
-            _, _, _ = loop.run_until_complete(initialize_agent())
+            agent, mcp_clients, available_tools = await initialize_agent()
         
         # Process user message
-        loop = asyncio.get_event_loop()
-        bot_response = loop.run_until_complete(process_message(message, chat_history))
+        bot_response = await process_message(message, chat_history)
         
         # Add assistant message to history
         chat_history.append({"role": "assistant", "content": bot_response})


### PR DESCRIPTION
## Issue:
Gradio chatbot can only answer one question and the app freezes on follow-up questions.

## Root Cause:

Gradio’s UI event system isn't fully async-native. Using `loop.run_until_complete()` inside the `respond()` callback created conflicts with Gradio’s internal event loop, leading to application blocking after the first request.

## Fix:

- Modified the `respond()` function to support async 
- Replaced `loop.run_until_complete()` with `await`

## Test:
<img width="1476" alt="image" src="https://github.com/user-attachments/assets/2e852024-ecd8-4f7c-968d-e46372d2d65a" />


